### PR TITLE
Wh delete category

### DIFF
--- a/Tabloid/Controllers/CategoryController.cs
+++ b/Tabloid/Controllers/CategoryController.cs
@@ -34,6 +34,11 @@ namespace Tabloid.Controllers
             _categoryRepository.Add(category);
             return CreatedAtAction("Get", new { id = category.Id }, category);
         }
-
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            _categoryRepository.Delete(id);
+            return NoContent();
+        }
     }
 }

--- a/Tabloid/Repositories/CategoryRepository.cs
+++ b/Tabloid/Repositories/CategoryRepository.cs
@@ -59,6 +59,7 @@ namespace Tabloid.Repositories
             }
         }
 
+        //Changes any tag's category associated with the targeted category to avoid deleting posts
         public void Delete(int id)
         {
             using (SqlConnection conn = Connection)

--- a/Tabloid/Repositories/CategoryRepository.cs
+++ b/Tabloid/Repositories/CategoryRepository.cs
@@ -58,5 +58,23 @@ namespace Tabloid.Repositories
                 }
             }
         }
+
+        public void Delete(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE Post 
+                                        SET CategoryId = 22 
+                                        WHERE CategoryId = @Id
+                                        DELETE FROM Category
+                                        WHERE Id = @Id";
+                    DbUtils.AddParameter(cmd, "@Id", id);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
     }
 }

--- a/Tabloid/Repositories/ICategoryRepository.cs
+++ b/Tabloid/Repositories/ICategoryRepository.cs
@@ -8,5 +8,6 @@ namespace Tabloid.Repositories
     {
         public void Add(Category category);
         List<Category> GetAll();
+        public void Delete(int id);
     }
 }

--- a/Tabloid/Repositories/TagRepository.cs
+++ b/Tabloid/Repositories/TagRepository.cs
@@ -57,7 +57,7 @@ namespace Tabloid.Repositories
                 }
             }
         }
-
+        //Deletes PostTag instances related to the tag we want to delete first due to the required FK of TagId
         public void Delete(int id)
         {
             using (SqlConnection conn = Connection)

--- a/Tabloid/client/src/components/Category.js
+++ b/Tabloid/client/src/components/Category.js
@@ -1,19 +1,59 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom"
-import { Table } from "reactstrap";
+import {
+  Card,
+  CardTitle,
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from "reactstrap";
 import { CategoryContext } from "../providers/CategoryProvider";
 
 const Category = ({ category }) => {
+    const { getAllCategories, deleteCategory } = useContext(CategoryContext);
+    const [modal, setModal] = useState(false);
+
+    const toggle = () => setModal(!modal);
+
     return (
-        <>
-            <tr>
-                <th scope="row">{category.listIndex}</th>
-                <td><h4>{category.name}</h4></td>
-                {/* Button Placeholder */}
-                {/* <td><div><Button>Edit</Button><Button>Delete</Button></div></td> */}
-            </tr>
-        </>
-    )
+      <>
+        <tr>
+          <th scope="row">{category.listIndex}</th>
+          <td>
+            <h4>{category.name}</h4>
+          </td>
+          <Button color="danger" size="sm" onClick={toggle}>
+            Delete
+          </Button>
+          <Modal isOpen={modal} toggle={toggle} style={{ textAlign: "center" }}>
+            <ModalHeader>Delete Tag: {category.name}</ModalHeader>
+            <ModalBody>
+              <b>Please confirm you would like to delete the tag:</b>
+              <br /> <em>{category.name}</em>
+              <br />
+              <br />
+              This action <b>can not</b> be undone.
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                color="danger"
+                onClick={() => {
+                  deleteCategory(category.id).then(getAllCategories);
+                  toggle();
+                }}
+              >
+                Delete
+              </Button>{" "}
+              <Button color="secondary" onClick={toggle}>
+                Cancel
+              </Button>
+            </ModalFooter>
+          </Modal>
+        </tr>
+      </>
+    );
 };
 
 export default Category;

--- a/Tabloid/client/src/components/Category.js
+++ b/Tabloid/client/src/components/Category.js
@@ -24,9 +24,12 @@ const Category = ({ category }) => {
           <td>
             <h4>{category.name}</h4>
           </td>
-          <Button color="danger" size="sm" onClick={toggle}>
-            Delete
-          </Button>
+          <td>
+            <Button color="danger" size="sm" onClick={toggle}>
+              Delete
+            </Button>
+          </td>
+
           <Modal isOpen={modal} toggle={toggle} style={{ textAlign: "center" }}>
             <ModalHeader>Delete Tag: {category.name}</ModalHeader>
             <ModalBody>

--- a/Tabloid/client/src/components/CategoryList.js
+++ b/Tabloid/client/src/components/CategoryList.js
@@ -11,7 +11,7 @@ const CategoryList = () => {
 
     useEffect(() => {
         getAllCategories();
-    }, []);
+    });
 
     return (
       <>

--- a/Tabloid/client/src/components/TagForm.js
+++ b/Tabloid/client/src/components/TagForm.js
@@ -9,16 +9,11 @@ const TagForm = () => {
   const history = useHistory();
 
   const handleControlledInputChange = (event) => {
-    //When changing a state object or array,
-    //always create a copy make changes, and then set state.
     const newTag = { ...tag };
-    //task is an object with properties.
-    //set the property to the new value
     newTag[event.target.name] = event.target.value;
-    //update state
     setTag(newTag);
   };
-
+    //Checks to ensure name is provided, calls fetch to add tag, redirects to tags index
   const handleSaveTag = () => {
     if (tag.name) {
         addTag({

--- a/Tabloid/client/src/providers/CategoryProvider.js
+++ b/Tabloid/client/src/providers/CategoryProvider.js
@@ -34,13 +34,23 @@ export const CategoryProvider = (props) => {
       })
     );
   };
-
+ const deleteCategory = (id) => {
+   debugger;
+   return getToken().then((token) =>
+     fetch(`${apiUrl}/${id}`, {
+       method: "DELETE",
+       headers: {
+         Authorization: `Bearer ${token}`,
+       },
+     })
+   );
+ };
   return (
     <CategoryContext.Provider
       value={{
         addCategory,
         getAllCategories,
-        categories
+        categories, deleteCategory
      }}
     >
       {props.children}


### PR DESCRIPTION
# Description

Allows users to delete categories. Posts associated with a deleted category will now be associated with the "Other" category.

Ticket # 11

## Type of change

_Please delete options that are not relevant_.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Sign in as any user
2. Navigate to "Category Management" in navbar
3. Add a new category
4. Navigate to posts, add a new post, and associate it with the newly created category.
5. Find the newly created category under category management and select delete.
6. Ensure a modal prompting confirmation of deletion is presented, with the name of the category listed.
7. Confirm deletion and ensure the category is no longer listed on the "Category Management" page or the database table.
8. Navigate to posts, find the post you associated with the created category, and ensure its category is now "Other"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
